### PR TITLE
Expose Ambient Display settings

### DIFF
--- a/parts/AndroidManifest.xml
+++ b/parts/AndroidManifest.xml
@@ -63,7 +63,7 @@
             android:label="@string/ambient_display_title"
             android:theme="@style/Theme.Main">
             <intent-filter>
-                <action android:name="org.lineageos.settings.device.DOZE_SETTINGS" />
+                <action android:name="com.aicp.settings.device.DOZE_SETTINGS" />
                 <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
         </activity>


### PR DESCRIPTION
Required after http://gerrit.aicp-rom.com/#/c/AICP/packages_apps_Settings/+/83078/

Should bring Doze settings under Settings > Display > Ambient Display 